### PR TITLE
Add dice result to harm messages

### DIFF
--- a/src/view/apps/DamageRollPromptApplication.js
+++ b/src/view/apps/DamageRollPromptApplication.js
@@ -27,7 +27,7 @@ export class DamageRollPromptApplication extends TJSDialog {
          title: dialogData.title ?? "Damage Roll",
          buttons: {
             confirm: {
-               autoClose: true,
+               autoClose: false,
                icon: 'fas fa-dice-d20',
                label: "Roll",
                onPress: 'requestSubmit'

--- a/src/view/apps/DamageRollPromptApplication.js
+++ b/src/view/apps/DamageRollPromptApplication.js
@@ -53,7 +53,7 @@ export class DamageRollPromptApplication extends TJSDialog {
     * 
     * @param dialog_data
     *
-    * @returns {Promise<string | number | null>} The value, or null if the user cancelled the prompt
+    * @returns {Promise<object | number | string | null>} The value, or null if the user cancelled the prompt
     */
    static async show(dialog_data = {}) {
       return new DamageRollPromptApplication(dialog_data).wait();

--- a/src/view/apps/DamageRollPromptShell.svelte
+++ b/src/view/apps/DamageRollPromptShell.svelte
@@ -46,13 +46,16 @@
         let formula = buildDamageFormula(die, dice_count, `${fray_count} * ${fray}`, bonus_damage);
         let roll = new Roll(formula);
         const result = await roll.roll()
+        if (game?.dice3d?.showForRoll) {
+            await game.dice3d.showForRoll(result, game.user, true, null, false, null, null, {ghost:false, secret:false});
+        }
         managedPromise.resolve({total: result.total, result: result.result});
         
         application.close();
     }
 </script>
 
-<form bind:this={form} on:submit|preventDefault={async (e) => await saveData(e)} autocomplete="off">
+<form bind:this={form} on:submit|preventDefault={saveData} autocomplete="off">
     <div class="flexrow">
         <div class="formula-grid">
             <!-- The main formula line -->

--- a/src/view/apps/DamageRollPromptShell.svelte
+++ b/src/view/apps/DamageRollPromptShell.svelte
@@ -41,13 +41,13 @@
      *
      * @returns {Promise<void>}
      */
-    function saveData(event) {
+    async function saveData(event) {
         // const fd = new FormDataExtended(event.target);
         let formula = buildDamageFormula(die, dice_count, `${fray_count} * ${fray}`, bonus_damage);
         let roll = new Roll(formula);
         roll.roll({ async: false });
 
-        managedPromise.resolve(roll.total);
+        managedPromise.resolve({total: roll.total, result: roll.result});
         application.close();
     }
 </script>

--- a/src/view/apps/DamageRollPromptShell.svelte
+++ b/src/view/apps/DamageRollPromptShell.svelte
@@ -45,14 +45,14 @@
         // const fd = new FormDataExtended(event.target);
         let formula = buildDamageFormula(die, dice_count, `${fray_count} * ${fray}`, bonus_damage);
         let roll = new Roll(formula);
-        roll.roll({ async: false });
-
-        managedPromise.resolve({total: roll.total, result: roll.result});
+        const result = await roll.roll()
+        managedPromise.resolve({total: result.total, result: result.result});
+        
         application.close();
     }
 </script>
 
-<form bind:this={form} on:submit|preventDefault={saveData} autocomplete="off">
+<form bind:this={form} on:submit|preventDefault={async (e) => await saveData(e)} autocomplete="off">
     <div class="flexrow">
         <div class="formula-grid">
             <!-- The main formula line -->

--- a/src/view/components/combat/HarmApplicator.svelte
+++ b/src/view/components/combat/HarmApplicator.svelte
@@ -10,11 +10,15 @@
     import { slide } from "svelte/transition";
 
     async function emitHarm(value) {
+        let dice_result = `${value}`;
         if(value === "cust.") {
             value = await RapidPromptApplication.show("number");
             if(!value) return;
         } else if (value === "roll") {
-            value = await DamageRollPromptApplication.show();
+            const damageRoll = await DamageRollPromptApplication.show();
+            const { total, result } = damageRoll;
+            value = total;
+            dice_result = result;
             if(!value) return;
         }
 
@@ -25,7 +29,8 @@
                 if ($ATTACKER?.actor) {
                     flags.push(...flagsForAttacker($ATTACKER?.actor));
                 }
-                items.push([target.actor, computeHarm(target.actor, selected_type, value, flags)]);
+                
+                items.push([target.actor, computeHarm(target.actor, selected_type, value, dice_result, flags)]);
             }
         }
         if (items.length) {

--- a/src/view/components/combat/HarmRecord.svelte
+++ b/src/view/components/combat/HarmRecord.svelte
@@ -13,7 +13,7 @@
     // Let the tooltip show how the damage was computed
     let tooltip;
     $: {
-        tooltip = `${record.harm.original_amount} ${record.harm.type}`;
+        tooltip = `${record.harm.original_amount} (${record.harm.dice_result}) ${record.harm.type}`;
         let amount = record.harm.original_amount;
         for (let [cause, delta] of record.harm.deltas) {
             amount += delta;


### PR DESCRIPTION
This adds the dice result of the damage roll to the tooltip (in parentheses) for the harm records in the damage planner.

![Screenshot_2024-06-01_at_12 13 19_PM](https://github.com/whitespine/foundryvtt-icon/assets/1403344/e0a702a8-acb0-4d6c-82bf-7af838541d6a)
